### PR TITLE
Update the Slack Invite Request URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Join the community on Slack at [https://atomicredteam.slack.com](https://atomicr
 * Using [ATT&CK Navigator](https://github.com/mitre-attack/attack-navigator)? Check out our coverage layers ([All](atomics/Indexes/Attack-Navigator-Layers/art-navigator-layer.json), [Windows](atomics/Indexes/Attack-Navigator-Layers/art-navigator-layer-windows.json), [MacOS](atomics/Indexes/Attack-Navigator-Layers/art-navigator-layer-macos.json), [Linux](atomics/Indexes/Attack-Navigator-Layers/art-navigator-layer-linux.json))
 * [Fork](https://github.com/redcanaryco/atomic-red-team/fork) and [Contribute](https://github.com/redcanaryco/atomic-red-team/wiki/Contributing) your own modifications
 * Have questions? Join the community on Slack at [https://atomicredteam.slack.com](https://atomicredteam.slack.com)
-    * Need a Slack invitation? Grab one at [https://slack.atomicredteam.io/](https://slack.atomicredteam.io/)
+    * Need a Slack invitation? Submit an invite request via this [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSc3oMtugGy--6kcYiY52ZJQQ-iOaEy-UpxfSA37IlA5wCMV0A/viewform?usp=sf_link)
 
 ## Code of Conduct
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -31,7 +31,7 @@
     <a href="apis" class="btn">APIs</a>
     <a href="related" class="btn">Related</a>
     <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-    <a href="https://slack.atomicredteam.io" class="btn">Join on Slack</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSc3oMtugGy--6kcYiY52ZJQQ-iOaEy-UpxfSA37IlA5wCMV0A/viewform?usp=sf_link" class="btn">Join on Slack</a>
 </section>
 
 <section class="main-content">


### PR DESCRIPTION
**Details:**
The web app for requesting a Slack invite no longer works due to a deprecated Slack API call. Moving requests to a (Red Canary provided) Google Form.

**Testing:**
N/A

**Associated Issues:**
N/A